### PR TITLE
Add a get_host_by_attrs method

### DIFF
--- a/infoblox.py
+++ b/infoblox.py
@@ -47,6 +47,7 @@ class Infoblox(object):
 	get_host
 	get_host_by_ip
 	get_ip_by_host
+	get_host_by_attrs
 	get_host_by_extattrs
 	get_host_extattrs
 	get_network


### PR DESCRIPTION
I needed a method to return a list of hosts, very similar to get_host_by_extattrs, but that didn't assume the use of extensible attributes.

My immediate use-case was to return a list of hosts which have a name that matches a regular expression.

get_host would only return an individual host, so I wanted something to return a list like get_host_by_extattrs, but ...by_extattrs inserted the "*" that made it only usable for extensible attributes.